### PR TITLE
Read GS log on GsApi error

### DIFF
--- a/Applications/Converter/Main/Sources/Message.cs
+++ b/Applications/Converter/Main/Sources/Message.cs
@@ -221,7 +221,7 @@ public static class Message
         CryptographicException => Surface.Texts.Error_Digest,
         EncryptionException    => Surface.Texts.Error_MergePassword,
         PostProcessException   => Surface.Texts.Error_PostProcess,
-        GsApiException e       => string.Format(Surface.Texts.Error_Ghostscript, e.Status),
+        GsApiException e       => System.IO.File.ReadAllText(e.logPath),
         ArgumentException      => src.Message,
         _                      => $"{src.Message} ({src.GetType().Name})",
     };

--- a/Libraries/Generating/Sources/Converter.cs
+++ b/Libraries/Generating/Sources/Converter.cs
@@ -276,7 +276,7 @@ public class Converter
 
         Logger.Debug(args.Join(" "));
         Io.CreateDirectory(Io.GetDirectoryName(dest));
-        GsApi.Invoke(args, Temp);
+        GsApi.Invoke(args, Temp, Log);
     }
 
     /* --------------------------------------------------------------------- */

--- a/Libraries/Generating/Sources/Internal/GsApi.cs
+++ b/Libraries/Generating/Sources/Internal/GsApi.cs
@@ -73,7 +73,7 @@ internal static class GsApi
     /// </summary>
     ///
     /* --------------------------------------------------------------------- */
-    public static void Invoke(string[] raw, string tmp) => SetTemp(tmp, () =>
+    public static void Invoke(string[] raw, string tmp, string log) => SetTemp(tmp, () =>
     {
         _ = NativeMethods.NewInstance(out var core, IntPtr.Zero);
         if (core == IntPtr.Zero) throw new GsApiException(GsApiStatus.UnknownError, "gsapi_new_instance");
@@ -84,7 +84,7 @@ internal static class GsApi
             foreach (var e in raw) args.Add(ToUtf8(e));
             NativeMethods.SetArgEncoding(core, 1 /*GS_ARG_ENCODING_UTF8*/ );
             var code = NativeMethods.InitWithArgs(core, args.Count, args.ToArray());
-            if (code < 0 && code != (int)GsApiStatus.Quit && code != (int)GsApiStatus.Info) throw new GsApiException(code);
+            if (code < 0 && code != (int)GsApiStatus.Quit && code != (int)GsApiStatus.Info) throw new GsApiException(code, log);
         }
         finally
         {

--- a/Libraries/Generating/Sources/Internal/GsApiException.cs
+++ b/Libraries/Generating/Sources/Internal/GsApiException.cs
@@ -55,6 +55,22 @@ public class GsApiException : Exception
     ///
     /// <summary>
     /// Initializes a new instance of the GsApiException class with
+    /// the specified status and message, log.
+    /// </summary>
+    ///
+    /// <param name="status">Status code.</param>
+    /// <param name="message">Message.</param>
+    /// <param name="log"> Filepath of GS log.</param>
+    ///
+    /* --------------------------------------------------------------------- */
+    public GsApiException(int status, string log) : 
+        this((GsApiStatus)Enum.ToObject(typeof(GsApiStatus), status), $"{status} ({status:D})", log) { }
+    /* --------------------------------------------------------------------- */
+    ///
+    /// GsApiException
+    ///
+    /// <summary>
+    /// Initializes a new instance of the GsApiException class with
     /// the specified status.
     /// </summary>
     ///
@@ -76,8 +92,28 @@ public class GsApiException : Exception
     /// <param name="message">Message.</param>
     ///
     /* --------------------------------------------------------------------- */
-    public GsApiException(GsApiStatus status, string message) :
-        base(message) => Status = status;
+    public GsApiException(GsApiStatus status, string message) : this(status, message, null) { }
+
+    /* --------------------------------------------------------------------- */
+    ///
+    /// GsApiException
+    ///
+    /// <summary>
+    /// Initializes a new instance of the GsApiException class with
+    /// the specified status and message, log.
+    /// </summary>
+    ///
+    /// <param name="status">Status code.</param>
+    /// <param name="message">Message.</param>
+    /// <param name="log"> Filepath of GS log.</param>
+    ///
+    /* --------------------------------------------------------------------- */
+    public GsApiException(GsApiStatus status, string message, string log) :
+        base(message)
+    {
+        Status = status;
+        logPath = log;
+    }
 
     #endregion
 
@@ -93,6 +129,16 @@ public class GsApiException : Exception
     ///
     /* --------------------------------------------------------------------- */
     public GsApiStatus Status { get; }
+    /* --------------------------------------------------------------------- */
+    ///
+    /// logPath
+    ///
+    /// <summary>
+    /// Gets the GS log filepath.
+    /// </summary>
+    ///
+    /* --------------------------------------------------------------------- */
+    public string logPath { get; }
 
     #endregion
 }


### PR DESCRIPTION
1. Add logPath property @ GsApiException
2. Add argument(log) @GsApi.Invoke. Converter passes Log property for that.
3. Read log file instead of Surface.Texts.Error_Ghostscrip @GetMessage