### PR TITLE
Implement process of adding "Direction" ViewerPreferences

### DIFF
--- a/Libraries/Itext/Sources/Internal/Writer.cs
+++ b/Libraries/Itext/Sources/Internal/Writer.cs
@@ -179,7 +179,29 @@ namespace Cube.Pdf.Itext
                     .SetCreator(src.Creator);
 
             var pl = src.Options.ToPageLayout();
-            if (pl != ViewerOption.None) _ = dest.GetCatalog().SetPageLayout(new(pl.ToName()));
+            if (pl != ViewerOption.None)
+            {
+                PdfName pageLayout = new(pl.ToName());
+                _ = dest.GetCatalog().SetPageLayout(pageLayout);
+
+                var viewerPreferences = dest.GetCatalog().GetViewerPreferences();
+                if (viewerPreferences is null)
+                {
+                    // Init ViewerPreferences
+                    viewerPreferences = new PdfViewerPreferences();
+                    dest.GetCatalog().SetViewerPreferences(viewerPreferences);
+                }
+
+                // Add Direction to ViewerPreferences
+                if (pl == ViewerOption.TwoColumnRight || pl == ViewerOption.TwoPageRight)
+                {
+                    viewerPreferences.SetDirection(PdfViewerPreferences.PdfViewerPreferencesConstants.RIGHT_TO_LEFT);
+                }
+                else
+                {
+                    viewerPreferences.SetDirection(PdfViewerPreferences.PdfViewerPreferencesConstants.LEFT_TO_RIGHT);
+                }
+            }
 
             var pm = src.Options.ToPageMode();
             if (pm != ViewerOption.None) _ = dest.GetCatalog().SetPageMode(new(pm.ToName()));


### PR DESCRIPTION
## Reason of change

When "Two page (right)" or "Two column (right)" is specified in "Metadata > Layout" in "CubePDF Pages", "Direction" is not specified, so when viewed in a PDF viewer such as Adobe Acrobat Reader, it is not displayed right-bound.

## Solution

Changed to add "RIGHT_TO_LEFT" when "TwoColumnRight" or "TwoPageRight" is specified in "ViewerOption".

---

_Pre-translation text_

## 変更の理由

「CubePDF Pages」で「文書プロパティ > ページレイアウト」に「見開きページ (右綴じ)」や「連続見開きページ (右綴じ)」を指定した時に"Direction"が指定されないため、Adobe Acrobat ReaderなどのPDFビュワーで閲覧した際に右綴じで表示されません。

## 解決策

「ViewerOption」として "TwoColumnRight" か "TwoPageRight" が指定された時、"RIGHT_TO_LEFT" を追加するよう変更しました。
